### PR TITLE
Fix example Grade in ADD_COMMAND usage instructions

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -36,7 +36,7 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_GRADE + "4.0 "
+            + PREFIX_GRADE + "A "
             + PREFIX_SUBJECT + "Mathematics "
             + PREFIX_TAG + "friends "
             + PREFIX_TAG + "owesMoney";


### PR DESCRIPTION
Right now, the example usage instructions suggest to input the grade as g/4.0, which raises an exception as the grades are specified to be an alphabet in the code. 

This PR changes the usage instructions to use 'A' instead

![Screenshot 2024-03-19 at 5 00 50 PM](https://github.com/AY2324S2-CS2103-F15-2/tp/assets/77627894/a806083b-ea2c-4952-881a-2cd098f7e3c8)
